### PR TITLE
Add in a SkipVersionCheck option.

### DIFF
--- a/devices/retroarchfactory.cpp
+++ b/devices/retroarchfactory.cpp
@@ -44,15 +44,18 @@ QStringList RetroArchFactory::listDevices()
         }
         sDebug() << "Connected";
     }
-    m_sock->write("VERSION");
-    m_sock->waitForReadyRead(100);
-    if(m_sock->hasPendingDatagrams())
+    if (!globalSettings->value("SkipVersionCheck", 0).toBool())
     {
-        raVersion = m_sock->readAll().trimmed();
-        sDebug() << "Received RA version : " << raVersion;
-    } else {
-        m_attachError = tr("RetroArch - Did not get a VERSION response.");
-        return toret;
+        m_sock->write("VERSION");
+        m_sock->waitForReadyRead(100);
+        if(m_sock->hasPendingDatagrams())
+        {
+            raVersion = m_sock->readAll().trimmed();
+            sDebug() << "Received RA version : " << raVersion;
+        } else {
+            m_attachError = tr("RetroArch - Did not get a VERSION response.");
+            return toret;
+        }
     }
     m_sock->write("READ_CORE_RAM FFC0 32");
     m_sock->waitForReadyRead(100);


### PR DESCRIPTION
The version of RetroArch that comes with Debian 10 doesn't respond to the `VERSION` command.
So, I added a config option to not do it.