### PR TITLE
Patches to make QUsb2Snes work in ArchLinux

### DIFF
--- a/devices/sd2snesdevice.cpp
+++ b/devices/sd2snesdevice.cpp
@@ -49,16 +49,24 @@ void SD2SnesDevice::close()
 
 void SD2SnesDevice::spReadyRead()
 {
+    while (m_port.bytesAvailable() >= blockSize)
+        readPacket(m_port.read(blockSize));
+}
+
+void SD2SnesDevice::readPacket(const QByteArray& packetData)
+{
+    Q_ASSERT(packetData.size() == blockSize);
+
     static QByteArray   responseBlock = QByteArray();
     static bool         firstBlock = true;
     static int          dataSent = 0;
 
-    qint64 bytesToRead = m_port.bytesAvailable();
-    bytesReceived += bytesToRead;
-    dataRead = m_port.readAll();
-    dataReceived.append(dataRead);
+    bytesReceived += packetData.size();
+    dataRead = packetData;
+    dataReceived.append(packetData);
 
-    sDebug() << "SP Received: " << bytesToRead << " (" << bytesReceived << ")";
+    //sDebug() << "<<" << packetData;
+    sDebug() << "SP Received: " << packetData.size() << " (" << bytesReceived << ")";
 
     /* If we've received over 512 bytes and NORESP is not set, parse response header */
     if(responseBlock.isEmpty() && dataReceived.size() >= 512 && (m_commandFlags & SD2Snes::server_flags::NORESP) == 0)

--- a/devices/sd2snesdevice.cpp
+++ b/devices/sd2snesdevice.cpp
@@ -292,7 +292,12 @@ void SD2SnesDevice::writeData(QByteArray data)
 
     auto written = m_port.write(data);
     sDebug() << "Written : " << written << " bytes";
+#ifdef Q_OS_LINUX
+    // Prevents a QSerialPort::ResourceError "Resource temporarily unavailable" error when uploading files to sd2snes.
+    m_port.waitForBytesWritten();
+#else
     m_port.flush();
+#endif
     if (m_currentCommand == SD2Snes::VPUT)
     {
         sDebug() << "Putsize: " << m_putSize << " sendSize:" << sendSize;

--- a/devices/sd2snesdevice.h
+++ b/devices/sd2snesdevice.h
@@ -58,6 +58,9 @@ private slots:
     void    onRTSChanged(bool set);
 
 private:
+    void    readPacket(const QByteArray& packetData);
+
+private:
     QSerialPort m_port;
 
     QByteArray  dataReceived;


### PR DESCRIPTION
On my system (Arch Linux 5.3.6-arch1-1-ARCH, Qt 5.13.1, usb2snes_v11), QUsb2Snes does not work, failing with either a `Protocol error: "\x00\x00\x00\x00\x00\x00"` or `QSerialPort::ResourceError "Resource temporarily unavailable"`.

This pull request contains two patches that fix these two bugs on my system.

 -- undisbeliever

P.S. I have placed the `QSerialPort::ResourceError` fix (commit 3b32c57) under a `Q_OS_LINUX` ifdef as I am unable to test if the commit breaks anything on windows/mac.