### PR TITLE
Added hints for config in linuxReadme.md and modified .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# C++ objects and libs
+*.slo
+*.lo
+*.o
+*.a
+*.la
+*.lai
+*.so
+*.so.*
+*.dll
+*.dylib
+
+# Qt-es
+object_script.*.Release
+object_script.*.Debug
+*_plugin_import.cpp
+/.qmake.cache
+/.qmake.stash
+*.pro.user
+*.pro.user.*
+*.qbs.user
+*.qbs.user.*
+*.moc
+moc_*.cpp
+moc_*.h
+qrc_*.cpp
+ui_*.h
+*.qmlc
+*.jsc
+Makefile*
+*build-*
+*.qm
+*.prl
+
+# Qt unit tests
+target_wrapper.*
+
+# QtCreator
+*.autosave
+
+# QtCreator Qml
+*.qmlproject.user
+*.qmlproject.user.*
+
+# QtCreator CMake
+CMakeLists.txt.user*
+
+# QtCreator 4.8< compilation database 
+compile_commands.json
+
+# QtCreator local machine specific files for imported projects
+*creator.user*
+
+*_qmlcache.qrc
+
+/QUsb2Snes
+/QUsb2Snes.conf

--- a/LinuxREADME.md
+++ b/LinuxREADME.md
@@ -15,7 +15,7 @@ Then start the QUsb2Snes binary from the `release` directory that is created.
 
 # Usage
 
-There is a -nogui option if you want to run it without the system tray icon and interface.
+There is a `-nogui` option if you want to run it without the system tray icon and interface.
 
 # Files
 
@@ -25,7 +25,13 @@ Logs are put in the standard path for application data. It should be:
 And the settings file is into
 ~/.config/skarsnik.nyo.fr/QUsb2Snes.conf
 
+To configure QUsb2snes for RetroArch when using `-nogui` option
 
+Add retroarchdevice to the config under General, for example:
+```
+[General]
+retroarchdevice=true
+```
 
 # SD2Snes
 


### PR DESCRIPTION
Added hints for config in LinuxReadme.md for use with RetoArch when using the -nogui option
Added modified .gitignore to exclude files generated by the compiler. 
  Original from https://github.com/github/gitignore/blob/master/Qt.gitignore 