### PR TITLE
RAHost: Fix writeMemory

### DIFF
--- a/devices/retroarchhost.cpp
+++ b/devices/retroarchhost.cpp
@@ -86,14 +86,15 @@ qint64 RetroArchHost::writeMemory(unsigned int address, unsigned int size)
 void RetroArchHost::writeMemoryData(QByteArray data)
 {
     writeMemoryBuffer.append(data);
+    assert(writeMemoryBuffer.size() <= writeSize);
     if (writeSize == writeMemoryBuffer.size())
     {
         QByteArray data = (readMemoryAPI ? "WRITE_CORE_MEMORY " : "WRITE_CORE_RAM ") + QByteArray::number(writeAddress, 16) + " ";
         data.append(writeMemoryBuffer.toHex(' '));
         data.append('\n');
         doCommmand(data);
-        commandTimeoutTimer.stop();
         if (!readMemoryAPI) { // old API does not send a reply
+            commandTimeoutTimer.stop();
             sDebug() << "Write memory done";
             state = None;
             emit writeMemoryDone(id);

--- a/devices/retroarchhost.cpp
+++ b/devices/retroarchhost.cpp
@@ -37,7 +37,6 @@ RetroArchHost::RetroArchHost(QString name, QObject *parent) : QObject(parent)
     commandTimeoutTimer.setInterval(500);
     commandTimeoutTimer.setSingleShot(true);
     connect(&socket, &QUdpSocket::readyRead, this, &RetroArchHost::onReadyRead);
-    connect(&socket, &QUdpSocket::bytesWritten, this, &RetroArchHost::onByteWritten);
 #if QT_VERSION >= QT_VERSION_CHECK(5,15,0)
     connect(&socket, &QUdpSocket::errorOccurred, this, &RetroArchHost::errorOccured);
     connect(&socket, &QUdpSocket::errorOccurred, this, [this]{
@@ -79,37 +78,27 @@ qint64 RetroArchHost::writeMemory(unsigned int address, unsigned int size)
         return -1;
     writeAddress = (int)raAddress;
     writeSize = (int)size;
-    writtenSize = 0;
     writeMemoryBuffer.clear();
+    writeMemoryBuffer.reserve(writeSize);
     return ++id;
 }
 
 void RetroArchHost::writeMemoryData(QByteArray data)
 {
-    writtenSize += data.size();
     writeMemoryBuffer.append(data);
-    if (writeSize == writtenSize)
+    if (writeSize == writeMemoryBuffer.size())
     {
         QByteArray data = (readMemoryAPI ? "WRITE_CORE_MEMORY " : "WRITE_CORE_RAM ") + QByteArray::number(writeAddress, 16) + " ";
         data.append(writeMemoryBuffer.toHex(' '));
         data.append('\n');
-        raWriteSize = data.size();
         doCommmand(data);
         commandTimeoutTimer.stop();
-    }
-}
-
-void RetroArchHost::onByteWritten(qint64 bytes)
-{
-    sDebug() << "Byte written " << raWriteSize << bytes;
-    if (state == WriteMemory && readMemoryAPI == false)
-    {
-        if (bytes == raWriteSize)
-        {
-            sDebug() << "Data written";
+        if (!readMemoryAPI) { // old API does not send a reply
+            sDebug() << "Write memory done";
             state = None;
             emit writeMemoryDone(id);
         }
+
     }
 }
 

--- a/devices/retroarchhost.h
+++ b/devices/retroarchhost.h
@@ -93,16 +93,13 @@ private:
     QByteArray      getMemoryDatas;
 
     QByteArray      writeMemoryBuffer;
-    int             writtenSize;
     int             writeSize;
-    int             raWriteSize;
     unsigned int    writeAddress;
 
     void    setInfoFromRomHeader(QByteArray data);
     void    makeInfoFail(QString error);
     void    onReadyRead();
     void    onPacket(QByteArray& data);
-    void    onByteWritten(qint64 bytes);
     void    onCommandTimerTimeout();
     int     translateAddress(unsigned int address);
     void    doCommmand(QByteArray cmd);


### PR DESCRIPTION
* fix old API writeMemory, broken in commit eb2e4f9 (signal never fires)
* add missing timeout for new API writeMemory