### PR TITLE
RA: add support for read rom (HiROM only), fallback to old API if possible

### DIFF
--- a/devices/retroarchdevice.cpp
+++ b/devices/retroarchdevice.cpp
@@ -81,6 +81,10 @@ USB2SnesInfo RetroArchDevice::parseInfo(const QByteArray &data)
     {
         info.flags << getFlagString(USB2SnesWS::NO_ROM_READ) << getFlagString(USB2SnesWS::NO_ROM_WRITE);
     }
+    else if (host->hasRomWriteAccess() == false)
+    {
+        info.flags << getFlagString(USB2SnesWS::NO_ROM_WRITE);
+    }
     info.deviceName = "RetroArch";
     info.flags << getFlagString(USB2SnesWS::NO_CONTROL_CMD);
     info.flags << getFlagString(USB2SnesWS::NO_FILE_CMD);

--- a/devices/retroarchdevice.cpp
+++ b/devices/retroarchdevice.cpp
@@ -201,7 +201,7 @@ void RetroArchDevice::getAddrCommand(SD2Snes::space space, unsigned int addr, un
     if (space != SD2Snes::SNES)
     {
         m_state = CLOSED;
-        sDebug() << "Error, address or space incorect";
+        sDebug() << "Error, bad address space" << space;
         close();
         emit protocolError();
         return ;
@@ -210,7 +210,7 @@ void RetroArchDevice::getAddrCommand(SD2Snes::space space, unsigned int addr, un
     if (reqId == -1)
     {
         m_state = CLOSED;
-        sDebug() << "Error, address or space incorect";
+        sDebug() << "Error, bad address";
         close();
         emit protocolError();
         return ;
@@ -231,7 +231,7 @@ void RetroArchDevice::putAddrCommand(SD2Snes::space space, unsigned int addr0, u
     if (space != SD2Snes::SNES)
     {
         m_state = CLOSED;
-        sDebug() << "Error, Only SNES space is usable";
+        sDebug() << "Error, bad address space" << space;
         close();
         emit protocolError();
         return ;
@@ -240,7 +240,7 @@ void RetroArchDevice::putAddrCommand(SD2Snes::space space, unsigned int addr0, u
     if (reqId == -1)
     {
         m_state = CLOSED;
-        sDebug() << "Error, address incorect";
+        sDebug() << "Error, bad address";
         close();
         emit protocolError();
         return ;

--- a/devices/retroarchhost.cpp
+++ b/devices/retroarchhost.cpp
@@ -286,7 +286,13 @@ void RetroArchHost::onPacket(QByteArray& data)
         {
             if (data.split(' ').at(2) == "-1")
             {
-                makeInfoFail("Could not read WRAM");
+                // fall back to READ_CORE_RAM (WRAM-only) for Snes9x core, RA>=1.9.2
+                if (m_version >= QVersionNumber(1,9,2)) {
+                    readMemoryAPI = false;
+                    doCommandNow({reqId, "READ_CORE_RAM 0 1", ReqInfoRRAMZero, nullptr});
+                } else {
+                    makeInfoFail("Incompatible, please update RetroArch");
+                }
                 break;
             }
             doCommandNow({reqId, "READ_CORE_MEMORY 40FFC0 32", ReqInfoRMemoryHiRomData, nullptr});

--- a/devices/retroarchhost.h
+++ b/devices/retroarchhost.h
@@ -69,6 +69,7 @@ public:
     QString         name() const;
     QString         gameTitle() const;
     bool            hasRomAccess() const;
+    bool            hasRomWriteAccess() const;
     QHostAddress    address() const;
     QString         lastInfoError() const;
 
@@ -92,6 +93,7 @@ private:
     QString         m_lastInfoError;
     bool            readRamHasRomAccess;
     bool            readMemoryAPI;
+    bool            readMemoryHasRomAccess;
     qint64          reqId;
     State           state;
     QTimer          commandTimeoutTimer;


### PR DESCRIPTION
* RA with Snes9x does not map anything for `READ_MEMORY` and `WRITE_MEMORY`, so fallback to `READ_RAM` and `WRITE_RAM` if possible
* RA with bsnes-mercury core maps ROM, but LoROM is broken: reading `$018000` actually returns `$010000` instead of `$008000`, so half of ROM is inaccessible. ExLoROM and ExHiROM is untested
* RA with bsnes-mercury core does not allow writing to ROM, so set that feature flag through `hasRomWriteAccess()`
* better debug messages when address translation fails