### PR TITLE
Add config file location to logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ compile_commands.json
 
 *_qmlcache.qrc
 
+# Macos specific files
+/.DS_Store
+/QUsb2Snes.app
+
 /QUsb2Snes
 /QUsb2Snes.conf
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Installation via other means (homebrew, chocolatey, etc.) is not planned at the 
 ### Configuration files
 
 Logs are put in the standard path for application data if you use an installed version.
-It should be: `$HOME/.local/share/QUsb2Snes` on Linux.
+It should be: `$HOME/.local/share/QUsb2Snes` on Linux and `$HOME/Library/Application Support/QUsb2Snes` on macOS.
 Otherwise, it will be in the directory where the executable is located.
 
 Please note that the directory will be named after the binary file. If you create a symlink on Linux (e.g. qusb2snes.exe), the directory will change accordingly.
 
-The settings file is located aside the executable on Windows or in `$HOME/.config/skarsnik.nyo.fr/QUsb2Snes.conf` on Linux.
+The settings file is located aside the executable on Windows, in `$HOME/.config/skarsnik.nyo.fr/QUsb2Snes.conf` on Linux, or in a `.plist` file inside `$HOME/Library/Preferences/` on macOS. QUsb2Snes logs the exact config file path at startup, so check the logs to confirm which file is being used.
 
 ### Enabling/Disabling emulators
 

--- a/main.cpp
+++ b/main.cpp
@@ -102,6 +102,7 @@ static void onCrash()
         exit(1);
     crashLog.write(QString("Running QUsb2Snes version " + qApp->applicationVersion() + "\n").toUtf8());
     crashLog.write(QString("Compiled against Qt" + QString(QT_VERSION_STR) + ", running" + qVersion() + "\n").toUtf8());
+    crashLog.write(QString("Config file " + globalSettings->fileName() + "\n").toUtf8());
     for (unsigned int i = 0; i < logDebugCrash.size(); i++)
     {
         crashLog.write(logDebugCrash.at(i).toUtf8() + "\n");
@@ -272,6 +273,7 @@ int main(int ac, char *ag[])
 #endif
     qInfo() << "Running QUsb2Snes version " << qApp->applicationVersion();
     qInfo() << "Compiled against Qt" << QT_VERSION_STR << ", running" << qVersion();
+    qInfo() << "Config file" << globalSettings->fileName();
     // let set some know trusted domain
     wsServer.addTrusted("https://www.multitroid.com");
     wsServer.addTrusted("https://multitroid.com");


### PR DESCRIPTION
- Added build instructions for Macos
- Added Macos specific files to gitignore
- Added VSCode specific files. TODO: include paths need to be added for other environments

- Closes #120
- Updated Readme with default locations. Qt can have the `QSettings` object write to a different folder if `XDG_CONFIG_HOME` is set, so wrote a little section that didn't go into that detail, but says to check the logs.