### PR TITLE
RetroArch host: Check header validity when reading rom info

### DIFF
--- a/devices/retroarchhost.h
+++ b/devices/retroarchhost.h
@@ -120,7 +120,7 @@ private:
     qint64          writeId;
 
     qint64  nextId();
-    void    setInfoFromRomHeader(QByteArray data);
+    bool    setInfoFromRomHeader(QByteArray data);
     void    makeInfoFail(QString error);
     void    onReadyRead();
     void    onPacket(QByteArray& data);


### PR DESCRIPTION
When running a SMZ3 multiworld ROM in RetroArch, I had trouble getting the web app to connect to QUsb2Snes.
I discovered that QUsb2Snes attempts to read the ROM header from several locations, but doesn't actually check that the data read is reasonable.
I modified the code a little to add a minimal sanity check, that is already in use by the SNES Classic device.

Note the call to `setInfoFromRomHeader` in the `ReqInfoRRAMHiRomData` state, which I'm not sure how to deal with.