### PR TITLE
Fix AUR workflow failing on pull requests

### DIFF
--- a/.github/workflows/aur-workflow.yml
+++ b/.github/workflows/aur-workflow.yml
@@ -11,67 +11,106 @@ on:
 
 env:
   package_name: qusb2snes
+  PUBLISH: false
+
+permissions:
+  contents: read
 
 jobs:
   update_package:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up SSH key for external repository
-        run: |
-          mkdir -p ~/.ssh/
-          echo "${{ secrets.AUR_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts
+      # Full history required: pkgver is r<commit-count>.<short-sha> from git rev-list /
+      # git rev-parse, and a shallow clone yields r1.<sha> — the version would go backwards.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
-      - name: Define target repository
+      - name: Determine target package and version
         run: |
-          if [[ ${{ github.ref_name }} == 'master' ]]; then
-            echo "REPO_NAME=${{ env.package_name }}-git" >> $GITHUB_ENV
+          if [[ "${{ github.ref_type }}" == 'tag' ]]; then
+            REPO_NAME="${{ env.package_name }}"
+            PKGVER="${{ github.ref_name }}"
+            PUBLISH=true
+          elif [[ "${{ github.event_name }}" == 'push' && "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]]; then
+            REPO_NAME="${{ env.package_name }}-git"
+            PKGVER="r$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
+            PUBLISH=true
           else
-            echo "REPO_NAME=${{ env.package_name }}" >> $GITHUB_ENV
+            REPO_NAME="${{ env.package_name }}-git"
+            PKGVER="r$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
           fi
+          {
+            echo "REPO_NAME=$REPO_NAME"
+            echo "PKGVER=$PKGVER"
+            echo "PUBLISH=$PUBLISH"
+          } >> "$GITHUB_ENV"
 
-      - name: Clone external repository
-        run: |
-          git clone ssh://aur@aur.archlinux.org/${{ env.REPO_NAME }}.git
+      - name: Clone AUR repository
+        run: git clone --depth 1 "https://aur.archlinux.org/${{ env.REPO_NAME }}.git"
 
-      - name: Update PKGBUILD and .SRCINFO
+      - name: Update pkgver in PKGBUILD
+        working-directory: ${{ env.REPO_NAME }}
         run: |
-          PKGBUILD_PATH="PKGBUILD"
-          sed -E -i.bak "s/^([[:space:]]*)(pkgver)[[:space:]]*=[[:space:]]*.*/\1\2=${{github.ref_name}}/" $PKGBUILD_PATH
-          if grep -q "^[[:space:]]*pkgver=${{github.ref_name}}" "$PKGBUILD_PATH"; then
-            rm -f "${PKGBUILD_PATH}.bak"
-            echo "Updated $PKGBUILD_PATH: pkgver=${{github.ref_name}}"
-            cat "$PKGBUILD_PATH"
-          else
-            echo "Error: failed to update pkgver in $PKGBUILD_PATH" >&2
-            echo "Backup saved as ${PKGBUILD_PATH}.bak" >&2
+          set -euo pipefail
+          sed -E -i.bak \
+            "s/^([[:space:]]*pkgver[[:space:]]*=[[:space:]]*).*/\1${PKGVER}/" PKGBUILD
+          if ! grep -qE "^[[:space:]]*pkgver[[:space:]]*=[[:space:]]*${PKGVER}$" PKGBUILD; then
+            echo "::error file=PKGBUILD::failed to set pkgver=${PKGVER}"
+            diff -u PKGBUILD.bak PKGBUILD || true
             exit 3
           fi
-        working-directory: ${{ env.REPO_NAME }}
+          rm -f PKGBUILD.bak
 
-      - name: Update .SRCINFO
+      # Without a fragment, source=() leaves makepkg at upstream origin/HEAD, so this
+      # would validate master and pass for a PR that breaks it. #commit= pins the
+      # checkout to the PR sha, reachable from upstream via refs/pull/N/head; #branch=
+      # cannot work, as makepkg's `git clone -s` working copy carries no refs/pull/*.
+      # Rewriting the container's copy leaves the published PKGBUILD untouched.
+      - name: Validate PKGBUILD against PR head
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          SRCINFO_PATH=".SRCINFO"
-          sed -E -i.bak "s/^([[:space:]]*)(pkgver)[[:space:]]*=[[:space:]]*.*/\1\2=${{github.ref_name}}/" "$SRCINFO_PATH"
-          if grep -q "^[[:space:]]*pkgver=${{github.ref_name}}" "$SRCINFO_PATH"; then
-            rm -f "${SRCINFO_PATH}.bak"
-            echo "Updated $SRCINFO_PATH: pkgver=${{github.ref_name}}"
-            cat "$SRCINFO_PATH"
-          else
-            echo "Error: failed to update pkgver in $SRCINFO_PATH" >&2
-            echo "Backup saved as ${SRCINFO_PATH}.bak" >&2
-            exit 3
-          fi
-        working-directory: ${{ env.REPO_NAME }}
+          docker run --rm -e HEAD_SHA -v "$PWD/${REPO_NAME}":/pkg:ro archlinux:base-devel bash -c '
+            set -euo pipefail
+            pacman -Syu --noconfirm --needed git
+            useradd -m builder
+            cp -r /pkg /home/builder/pkg
+            sed -E -i \
+              "s|(git\+https://github.com/Skarsnik/QUsb2snes)\"|\1#commit=${HEAD_SHA}\"|" \
+              /home/builder/pkg/PKGBUILD
+            grep -q "#commit=${HEAD_SHA}" /home/builder/pkg/PKGBUILD
+            chown -R builder /home/builder/pkg
+            su builder -c "cd /home/builder/pkg && makepkg --nobuild --nodeps"
+          '
 
+      - name: Summarise result
+        working-directory: ${{ env.REPO_NAME }}
+        run: |
+          {
+            if [[ "${PUBLISH}" == 'true' ]]; then
+              echo "### Publishing \`${REPO_NAME}\` at \`${PKGVER}\`"
+            else
+              echo "### Dry run: \`${REPO_NAME}\` at \`${PKGVER}\` (nothing is pushed)"
+            fi
+            echo
+            echo '```diff'
+            git --no-pager diff -- PKGBUILD
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # No .SRCINFO step needed: the action copies only PKGBUILD into its own clone
+      # (build.sh L105), regenerates .SRCINFO via `makepkg --printsrcinfo` (L130-133)
+      # and stages both (L146).
       - name: Push to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        if: ${{ env.PUBLISH == 'true' }}
+        uses: KSXGitHub/github-actions-deploy-aur@v4.2.0
         with:
           pkgname: ${{ env.REPO_NAME }}
           pkgbuild: ${{ env.REPO_NAME }}/PKGBUILD
           commit_username: ${{ secrets.AUR_USERNAME }}
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          commit_message: Update AUR package
+          commit_message: Update AUR package to ${{ env.PKGVER }}
           ssh_keyscan_types: rsa,ecdsa,ed25519


### PR DESCRIPTION
# Problem

Every `pull_request` run fails on AUR workflow, and has since `20429d7`. Forks get no secrets, so
`AUR_SSH_PRIVATE_KEY` is empty and the clone step dies:

```md
Load key "/home/runner/.ssh/id_rsa": error in libcrypto
aur@aur.archlinux.org: Permission denied (publickey).
```

Two further problems surfaced while fixing it.

1. **PRs selected the wrong package.** Target selection tested
`github.ref_name == 'master'`, but on a `pull_request` event `ref_name` is
`<pr-number>/merge`, so it fell through to the stable `qusb2snes` package — run
`31024962069` reached the clone step with `REPO_NAME: qusb2snes`. Never
consequential, since every PR to date came from a fork and died at the clone for
lack of secrets; a same-repo branch PR does get secrets, so the wrong target
would have been reachable.

1. **Pushes to master were no-ops.** `pkgver` was set to `github.ref_name` — the
literal string `master` — over a `PKGBUILD` already reading `pkgver=master`. No
diff, and the action defaults to `allow_empty_commits: false`, so
`Everything up-to-date`. Hence the AUR page still showing `master-1`, last
updated 2025-11-16.

## Changes

- **Anonymous HTTPS clone instead of SSH**, so everything up to the push runs
without secrets and fork PRs exercise the same logic a merge would. The SSH-key
setup step is dropped; the deploy action does its own keyscan and key import.

- **Publishing gated on the event.** `PUBLISH` defaults to `false`, set `true` only
for tag and master pushes, with `if: ${{ env.PUBLISH == 'true' }}` on the push step.
Target selection keys off `github.ref_type == 'tag'`. `secrets` cannot be
referenced in an `if:`, hence gating on the event rather than on key presence.

- **Computed version for the `-git` package**: master pushes write
`r<commit-count>.<short-sha>`, matching the convention in the package's own
`pkgver()`. Requires `fetch-depth: 0` — the default shallow checkout yields
`r1.<sha>`, which would make the version go backwards and break upgrades.

- **Dropped the `.SRCINFO` edit** as dead code: the action copies only `PKGBUILD`
into its working clone, then regenerates `.SRCINFO` via `makepkg --printsrcinfo`
and stages both ([`build.sh` L105](https://github.com/KSXGitHub/github-actions-deploy-aur/blob/v4.2.0/build.sh#L105),
[L130-133](https://github.com/KSXGitHub/github-actions-deploy-aur/blob/v4.2.0/build.sh#L130-L133),
[L146](https://github.com/KSXGitHub/github-actions-deploy-aur/blob/v4.2.0/build.sh#L146)).
It was also corrupting the format — `.SRCINFO` uses `pkgver = value` with spaces,
and the `\1\2=` replacement collapsed them. The remaining `PKGBUILD` sed captures
the whole separator.

- **PRs validate the PKGBUILD against the PR's own code.** `makepkg` runs in an
`archlinux:base-devel` container. The action's `test` input cannot serve as a dry
run: `build.sh` asserts a non-empty `ssh_private_key` (L59) before reaching the
build (L123), and the push is unconditional. The source needs pinning to get any
PR value out of it — `source=()` carries no fragment, so `makepkg` leaves the tree
at upstream `origin/HEAD` (`git.sh` L116-129, L141) and `qusb2snes-git`'s `build()`
runs `qmake6` with no checkout, which would pass for a PR that breaks the build.
The step therefore rewrites the source with
`#commit=${{ github.event.pull_request.head.sha }}`, reachable from upstream via
`refs/pull/N/head` so no fork URL is involved. `#branch=` cannot work: `git.sh`
maps it to `origin/<name>` and the `git clone -s` working copy carries no
`refs/pull/*`. The rewrite is applied to the container's copy, leaving the
published `PKGBUILD` untouched.

  Scope: `--nobuild` stops before `build()` and `--nodeps` skips `qt6-base`, so this
validates rather than compiles — parse, source fetch, `.desktop` md5sums,
`prepare()` and `pkgver()`. Compiling is already covered on every PR by
`buildlinux.yml` and `buildflatpak.yml`, the latter on Qt6 from the actual checkout.

- Also `permissions: contents: read`, and the published version in the commit
message.

## Resulting behaviour

| Event | Package | pkgver (example) | Validates | Pushes to AUR |
|---|---|---|---|---|
| Tag push | `qusb2snes` | `v0.7.40` | — | yes |
| Master push | `qusb2snes-git` | `r605.e64baec` | — | yes |
| Pull request | `qusb2snes-git` | irrelevant | PR head | no |

Publishes are left unguarded deliberately. The action runs `makepkg --printsrcinfo`
under `set -o errexit` before the commit and push, so an unparseable `PKGBUILD`
fails the run with nothing reaching AUR — it exits 6 on a syntax error. Enabling the
action's `test` input would add a several-minute Qt6 build to every publish, need
`--syncdeps` to work at all (its default `--nodeps` never installs `qt6-base`), and
for `qusb2snes-git` would build upstream `origin/HEAD` rather than the commit being
published. Since this workflow only rewrites the `pkgver=` line, a
parses-but-won't-build failure would originate in the AUR repo, not here.

## Verification

Run locally against the real AUR repositories:

- Anonymous HTTPS clone of both packages, no credentials.
- `sed` rewrite against the real `PKGBUILD`: `pkgver=master` → `pkgver=r605.e64baec`,
  `.SRCINFO` untouched.
- `makepkg --printsrcinfo` emits the static `pkgver=` and does **not** evaluate
  `pkgver()`, so the computed version reaches `.SRCINFO`.
- `fetch-depth: 0` gives `r605.e64baec`; `--depth 1` gives `r1.e64baec`.
- Source pinning, through `makepkg`'s own two-step clone: without the fragment the
  tree resolves to `e64baec` (upstream master), with `#commit=` to `a681517` (this
  PR's head at the time). The `--mirror` clone does carry `refs/pull/*`, but the
  `clone -s` working copy does not, which is why `#branch=pull/N/head` fails.
- The source rewrite leaves `url=` and the EmuNWAccess-qt source line untouched.
- `makepkg --printsrcinfo` exits 6 on a malformed `PKGBUILD`, confirming the publish
  path fails before pushing.
- The tag path already works: `v0.7.36` published via this workflow on
  2026-02-10 (run `21861666187`, AUR commit `19be0a5`).

## Known limitation: upstream `PKGBUILD` bug

`qusb2snes-git`'s `pkgver()` does `cd "$srcdir/$_reponame"`, but `_reponame` is
never set — only `_projname` is. The empty expansion makes it `cd "$srcdir/"`,
which succeeds and lands in the packaging repo's own tree, so the version derives
from the AUR repository's history: `r14.32381fb`.

So the AUR page will advertise `r605.e64baec` while installs report
`r14.32381fb`, and `pacman -Syu` will offer an upgrade that never satisfies. The
fix is one word, in the maintainer's AUR repository, and cannot be applied from
here. @ChTPwner would need to apply [pkgbuild.patch](https://github.com/user-attachments/files/30755737/pkgbuild.patch) against AUR for `qusb2snes-git`

Note that AUR package adoption was disabled on 30 Jul 2026 pending the malicious-package
situation ([aur-general](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/thread/DRDEU3JUSC72CB265XHXPFA3DFSLXPBP/)),
so this may have to wait until normal AUR operations resume.
